### PR TITLE
Add ACM KDD 2026 badge to VisionDES card

### DIFF
--- a/software/index.md
+++ b/software/index.md
@@ -13,7 +13,7 @@ nav:
     <p class="team-hero-sub">Open-source tools, libraries, and datasets from InfoLab research — freely available for the research community.</p>
     <div class="team-hero-stats">
       <div class="team-hstat">
-        <span class="team-hstat-num">23</span>
+        <span class="team-hstat-num">21</span>
         <span class="team-hstat-lbl">Repositories</span>
       </div>
       <div class="team-hstat-sep"></div>
@@ -137,6 +137,7 @@ nav:
         <span class="sw-tag">ImageNet</span>
       </div>
       <div class="sw-card-footer">
+        <span class="sw-paper-badge sw-badge--acm">ACM KDD 2026</span>
         <a href="https://github.com/InfoLab-SKKU/VisionDES" target="_blank" rel="noopener" class="sw-gh-btn"><i class="fa-brands fa-github"></i> GitHub</a>
       </div>
     </div>


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
